### PR TITLE
✨ [Feat] : SPOFO 244 - 주식 서버에서 미비한 예외 처리를 구현한다.

### DIFF
--- a/src/main/java/spofo/stock/exception/ErrorCode.java
+++ b/src/main/java/spofo/stock/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생"),
-    INVALID_KIS_KEY(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰")
+    INVALID_KIS_KEY(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰"),
+    INVALID_STOCK_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 종목 코드")
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/spofo/stock/exception/ErrorCode.java
+++ b/src/main/java/spofo/stock/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생"),
+    INVALID_KIS_KEY(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰")
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/spofo/stock/exception/ErrorCode.java
+++ b/src/main/java/spofo/stock/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     INVALID_KIS_KEY(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰"),
     INVALID_STOCK_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 종목 코드")
     ;
+
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/spofo/stock/exception/ErrorResponse.java
+++ b/src/main/java/spofo/stock/exception/ErrorResponse.java
@@ -1,13 +1,15 @@
 package spofo.stock.exception;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@AllArgsConstructor
 @Getter
+@AllArgsConstructor
 public class ErrorResponse {
 
-    private HttpStatus httpStatus;
+    private HttpStatus status;
+    private int code;
     private String message;
 }

--- a/src/main/java/spofo/stock/exception/GlobalControllerAdvice.java
+++ b/src/main/java/spofo/stock/exception/GlobalControllerAdvice.java
@@ -19,7 +19,7 @@ public class GlobalControllerAdvice {
     }
 
     @ExceptionHandler(StockException.class)
-    public ResponseEntity<?> applicationExceptionHandler(StockException e) {
+    public ResponseEntity<?> stockExceptionHandler(StockException e) {
         ErrorResponse exceptionResponse = new ErrorResponse(
                 e.getHttpStatus(),
                 e.getMessage());

--- a/src/main/java/spofo/stock/exception/GlobalControllerAdvice.java
+++ b/src/main/java/spofo/stock/exception/GlobalControllerAdvice.java
@@ -1,6 +1,5 @@
 package spofo.stock.exception;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,7 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalControllerAdvice {
 
-    @ExceptionHandler(RuntimeException.class)
+    @ExceptionHandler
     public ResponseEntity<?> runtimeExceptionHandler(RuntimeException e) {
 
         return ResponseEntity
@@ -17,14 +16,14 @@ public class GlobalControllerAdvice {
                 .body(e.getMessage());
     }
 
-    @ExceptionHandler(StockException.class)
+    @ExceptionHandler
     public ResponseEntity<?> stockExceptionHandler(StockException e) {
-        ErrorResponse exceptionResponse = new ErrorResponse(
-                e.getHttpStatus(),
-                e.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(e.getStatus(),
+                e.getStatus().value(), e.getMessage());
 
         return ResponseEntity
-                .status(exceptionResponse.getHttpStatus())
-                .body(exceptionResponse);
+                .status(e.getStatus())
+                .body(errorResponse);
     }
 }

--- a/src/main/java/spofo/stock/exception/GlobalControllerAdvice.java
+++ b/src/main/java/spofo/stock/exception/GlobalControllerAdvice.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-@RequiredArgsConstructor
 public class GlobalControllerAdvice {
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/spofo/stock/exception/StockException.java
+++ b/src/main/java/spofo/stock/exception/StockException.java
@@ -9,12 +9,12 @@ import org.springframework.http.HttpStatus;
 public class StockException extends RuntimeException {
 
     private ErrorCode errorCode;
-    private HttpStatus httpStatus;
+    private HttpStatus status;
     private String message;
 
     public StockException(ErrorCode errorCode) {
         this.errorCode = errorCode;
-        this.httpStatus = errorCode.getHttpStatus();
+        this.status = errorCode.getHttpStatus();
         this.message = null;
     }
 

--- a/src/main/java/spofo/stock/service/StockService.java
+++ b/src/main/java/spofo/stock/service/StockService.java
@@ -92,7 +92,7 @@ public class StockService {
 
     private String getStockFromRedis(String stockCode) {
         String stockName = stockSearchRepository.findStockNameByStockCode(stockCode)
-                .orElseThrow(() -> new StockException(ErrorCode.INTERNAL_SERVER_ERROR));
+                .orElseThrow(() -> new StockException(ErrorCode.INVALID_STOCK_CODE));
         setValueToRedis(stockCode, stockName, Duration.ofDays(30));
         return stockName;
     }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
SPOFO-244 -> main

### 변경 사항
- 예외 발생 시 반환할 때 상태 코드만을 담은 필드를 추가했습니다.
<img width="261" alt="image" src="https://github.com/SP0F0/spofo-stock/assets/89517818/40a96214-90af-49bc-80e8-15eca35c127a">

- 클라이언트가 유효하지 않은 종목 코드를 요청하면 예외를 반환합니다.
- 외부 API 호출 시 토큰이 비정상이면 서부 내버 에러 예외를 반환합니다. 
- 에러 반환 객체의 변수명들을 수정했습니다. httpStatus -> status
- 자잘하게 코드 정리했습니다.

### 테스트 결과

